### PR TITLE
Add sample count command

### DIFF
--- a/signscan/__main__.py
+++ b/signscan/__main__.py
@@ -210,5 +210,41 @@ def bayes_complex(ctx, n):
     if show_plot:
         plt.show()
 
+
+@signscan.command()
+@click.pass_context
+def count_samples(ctx):
+    """
+    Outputs the number of samples for each discovered label.
+    """
+    print("loading data...")
+    x_train, y_train, _ = load_data(ctx.obj["data_folder"])
+
+    save_plot = ctx.obj["save_plot"]
+    show_plot = ctx.obj["show_plot"]
+
+    label_classifiers = fit_labels(x_train, y_train)
+
+    print("")
+    print("enumerated sample counts:")
+    for key, frame in y_train._asdict().items():
+        print(f" - {key}: {frame[frame.label==0].shape[0]}")
+    print("total: ", len(x_train))
+
+    plt.scatter(
+        x=[frame[frame.label==0].shape[0] for frame in y_train._asdict().values()],
+        y=[c.correct_predictions/c.total_predictions for c in label_classifiers.values()]
+    )
+    plt.xlabel("number of samples")
+    plt.ylabel("prediction accuracy")
+
+    if save_plot is not None:
+        os.makedirs(save_plot, exist_ok=True)
+        plt.savefig(os.path.join(save_plot, "sample_size_correlation.png"))
+
+    if show_plot:
+        plt.show()
+
+
 if __name__ == "__main__":
     signscan()


### PR DESCRIPTION
This adds a command that gets the number of samples per label

Example output

```
loading data...
  [####################################]  100%          

enumerated sample counts:
 - limit_60: 1410
 - limit_80: 1860
 - limit_80_lifted: 420
 - right_of_way_crossing: 1320
 - right_of_way: 2100
 - give_way: 2160
 - stop: 780
 - no_speed_limit: 240
 - turn_right_down: 2070
 - turn_left_down: 300
total:  12660
```